### PR TITLE
BatchUnlockAcorns addresses set max count to 20.

### DIFF
--- a/contract/Contracts.HamsterWoods/HamsterWoodsContract_Action.cs
+++ b/contract/Contracts.HamsterWoods/HamsterWoodsContract_Action.cs
@@ -148,7 +148,7 @@ public partial class HamsterWoodsContract : HamsterWoodsContractContainer.Hamste
     public override Empty BatchUnlockAcorns(UnlockAcornsInput input)
     {
         Assert(State.ManagerList.Value.Value.Contains(Context.Sender), "No permission.");
-        Assert(input.Addresses.Count > 0 && input.Addresses.Count < 20, "Invalid addresses.");
+        Assert(input.Addresses.Count > 0 && input.Addresses.Count <= 20, "Invalid addresses.");
         Assert(input.WeekNum > 0 && input.WeekNum < State.CurrentWeek.Value, "Invalid weekNum.");
 
         foreach (var address in input.Addresses)


### PR DESCRIPTION
### Expected Behavior
BatchUnlockAcorns addresses set max count to 20.

### Specifications
BatchUnlockAcorns addresses set max count to 20.

**Features:**
- BatchUnlockAcorns addresses set max count to 20.

**Development Tasks:**
- BatchUnlockAcorns addresses set max count to 20.

### Dependencies
nil

### References
nil